### PR TITLE
Always add newline before output

### DIFF
--- a/examples/quoth-php.php
+++ b/examples/quoth-php.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Many ways to say the same thing.
  */

--- a/examples/simple-array-7.3.php
+++ b/examples/simple-array-7.3.php
@@ -1,4 +1,5 @@
 <?php
+
 return [
   'name' => 'hello',
   'label' => 'Hello World!',

--- a/examples/simple-array-7.4.php
+++ b/examples/simple-array-7.4.php
@@ -1,4 +1,5 @@
 <?php
+
 return [
   'name' => 'hello',
   'label' => 'Hello World!',

--- a/examples/use-without-comments.php
+++ b/examples/use-without-comments.php
@@ -1,0 +1,6 @@
+<?php
+use SomeClass;
+
+return [
+  'foo' => SomeClass::create('bar'),
+];

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -22,8 +22,8 @@ class Printer {
         $buf[] = sprintf('use %s as %s;', $class, $alias);
       }
     }
+    $buf[] = '';
     if ($document->getOuterComments()) {
-      $buf[] = '';
       $buf[] = rtrim(implode("", $document->getOuterComments()), "\n");
     }
     $buf[] = 'return ' . $this->printNode($document->getRoot()) . ";\n";

--- a/tests/NewDocumentTest.php
+++ b/tests/NewDocumentTest.php
@@ -141,7 +141,7 @@ class NewDocumentTest extends \PHPUnit\Framework\TestCase {
     ];
     $this->assertEquals($expectExport, $doc->getRoot()->exportData());
 
-    $expectString = '<' . "?php\nreturn [\n"
+    $expectString = '<' . "?php\n\nreturn [\n"
       . "  'id' => 123,\n"
       . "  'name' => 'hello',\n"
       . "  'options' => [4, 5],\n"

--- a/tests/NewDocumentTest.php
+++ b/tests/NewDocumentTest.php
@@ -94,6 +94,24 @@ class NewDocumentTest extends \PHPUnit\Framework\TestCase {
     $this->assertEquals($expected, $actual);
   }
 
+  public function testCreateUseWithoutComment() {
+    $example = 'use-without-comments.php';
+
+    $basicData = [
+      'foo' => ScalarNode::create('bar')->setFactory('SomeClass::create'),
+    ];
+
+    $doc = PhpArrayDocument::create();
+    $doc->addUse('SomeClass');
+    $doc->getRoot()->importData($basicData);
+
+    $printer = new Printer();
+    $actual = $printer->print($doc);
+    $file = dirname(__DIR__) . '/examples/' . $example;
+    $expected = file_get_contents($file);
+    $this->assertEquals($expected, $actual);
+  }
+
   public function testCreateImportDataWithNodes() {
     $example = version_compare(PHP_VERSION, '7.4', '<') ? 'simple-array-7.3.php' : 'simple-array-7.4.php';
 

--- a/tests/ReadWriteTest.php
+++ b/tests/ReadWriteTest.php
@@ -45,7 +45,7 @@ class ReadWriteTest extends \PHPUnit\Framework\TestCase {
 
   public function testPreferSingleQuotes() {
     $input = '<' . '?php return ["ab cd"];';
-    $expect = '<' . "?php\nreturn ['ab cd'];\n";
+    $expect = '<' . "?php\n\nreturn ['ab cd'];\n";
     $doc = (new Parser())->parse($input);
     $output = (new Printer())->print($doc);
     $this->assertEquals($expect, $output);


### PR DESCRIPTION
Before
-----

Exporting a managed file gives a linting error:

```
FILE: ...n_ui/managed/SavedSearch_Administer_Custom_Field_Options.mgd.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 2 | ERROR | [x] There must be one blank line after the last USE
   |       |     statement; 0 found;
----------------------------------------------------------------------
```

After
-----
No error